### PR TITLE
feat: add theme palette and bootstrap overrides

### DIFF
--- a/onevision/hosting/app.html
+++ b/onevision/hosting/app.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>OneVision • App</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5waTHZ5PZr3QdorE2vLePoHB1zIYd2xt1kxgLZcflBNO8Y+0Y" crossorigin="anonymous">
+  <link rel="stylesheet" href="./assets/css/theme.css">
   <link rel="stylesheet" href="./assets/css/bootstrap.custom.css">
   <link rel="stylesheet" href="./assets/css/app.css">
 </head>

--- a/onevision/hosting/assets/css/bootstrap.custom.css
+++ b/onevision/hosting/assets/css/bootstrap.custom.css
@@ -1,2 +1,14 @@
+@import url('./theme.css');
+
+:root {
+  --bs-body-bg: var(--color-neutral-50);
+  --bs-body-color: var(--color-neutral-900);
+  --bs-primary: var(--color-primary);
+  --bs-font-sans-serif: var(--font-family-base);
+  --bs-body-font-size: 0.95rem;
+}
+
 /* Custom Bootstrap overrides */
-body { padding-top: 60px; }
+body {
+  padding-top: 60px;
+}

--- a/onevision/hosting/assets/css/theme.css
+++ b/onevision/hosting/assets/css/theme.css
@@ -1,0 +1,24 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+:root {
+  /* Neutral palette */
+  --color-neutral-50: #f8f9fa;
+  --color-neutral-100: #e9ecef;
+  --color-neutral-200: #dee2e6;
+  --color-neutral-300: #ced4da;
+  --color-neutral-900: #212529;
+
+  /* Primary highlight */
+  --color-primary: #4f46e5;
+
+  /* Typography */
+  --font-family-base: 'Inter', sans-serif;
+}
+
+body {
+  font-family: var(--font-family-base);
+  font-size: 0.95rem;
+  line-height: 1.5;
+  background-color: var(--bs-body-bg);
+  color: var(--bs-body-color);
+}

--- a/onevision/hosting/index.html
+++ b/onevision/hosting/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>OneVision • 4Credit</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5waTHZ5PZr3QdorE2vLePoHB1zIYd2xt1kxgLZcflBNO8Y+0Y" crossorigin="anonymous">
+  <link rel="stylesheet" href="./assets/css/theme.css">
   <link rel="stylesheet" href="./assets/css/bootstrap.custom.css">
 </head>
 <body class="d-flex align-items-center justify-content-center vh-100">


### PR DESCRIPTION
## Summary
- add theme.css with neutral palette, primary highlight and Inter typography
- import theme and override Bootstrap variables in custom stylesheet
- include theme.css in app and index pages for consistent fonts and spacing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_689781978b1483338553dfe28ce6a5d9