### PR TITLE
style: customize toast theme

### DIFF
--- a/onevision/hosting/app.html
+++ b/onevision/hosting/app.html
@@ -7,6 +7,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5waTHZ5PZr3QdorE2vLePoHB1zIYd2xt1kxgLZcflBNO8Y+0Y" crossorigin="anonymous">
   <link rel="stylesheet" href="./assets/css/bootstrap.custom.css">
   <link rel="stylesheet" href="./assets/css/app.css">
+  <link rel="stylesheet" href="./assets/css/theme.css">
 </head>
 <body>
   <nav class="navbar bg-light px-3">

--- a/onevision/hosting/assets/css/theme.css
+++ b/onevision/hosting/assets/css/theme.css
@@ -1,0 +1,30 @@
+.toast {
+  border-radius: 0.5rem;
+  background-color: #fff;
+  box-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.1);
+}
+
+.text-bg-success {
+  background-color: #d1e7dd !important;
+  color: #0f5132 !important;
+}
+
+.text-bg-danger {
+  background-color: #f8d7da !important;
+  color: #842029 !important;
+}
+
+.text-bg-warning {
+  background-color: #fff3cd !important;
+  color: #664d03 !important;
+}
+
+.text-bg-info {
+  background-color: #cff4fc !important;
+  color: #055160 !important;
+}
+
+.text-bg-primary {
+  background-color: #cfe2ff !important;
+  color: #084298 !important;
+}

--- a/onevision/hosting/assets/js/ui.js
+++ b/onevision/hosting/assets/js/ui.js
@@ -1,6 +1,6 @@
 export function showToast(message, type = 'info') {
   const toastEl = document.createElement('div');
-  toastEl.className = `toast align-items-center text-bg-${type} border-0`;
+  toastEl.className = `toast fade align-items-center text-bg-${type} border-0`;
   toastEl.setAttribute('role', 'alert');
   toastEl.innerHTML = `<div class="d-flex"><div class="toast-body">${message}</div><button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"></button></div>`;
   document.body.appendChild(toastEl);

--- a/onevision/hosting/index.html
+++ b/onevision/hosting/index.html
@@ -6,6 +6,7 @@
   <title>OneVision • 4Credit</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5waTHZ5PZr3QdorE2vLePoHB1zIYd2xt1kxgLZcflBNO8Y+0Y" crossorigin="anonymous">
   <link rel="stylesheet" href="./assets/css/bootstrap.custom.css">
+  <link rel="stylesheet" href="./assets/css/theme.css">
 </head>
 <body class="d-flex align-items-center justify-content-center vh-100">
   <div class="container" style="max-width:400px">


### PR DESCRIPTION
## Summary
- add theme.css with pastel toast palette and rounded styling
- link theme stylesheet in app and login pages
- enable fade transitions on toast notifications

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_689781c4c770833398eef3cae91b6ed3