### PR TITLE
feat: style login card

### DIFF
--- a/onevision/hosting/assets/css/theme.css
+++ b/onevision/hosting/assets/css/theme.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Poppins:wght@600&display=swap');
 
 :root {
   /* Neutral palette */
@@ -19,6 +19,10 @@ body {
   font-family: var(--font-family-base);
   font-size: 0.95rem;
   line-height: 1.5;
-  background-color: var(--bs-body-bg);
+  background: linear-gradient(135deg, var(--color-neutral-50), var(--color-neutral-100));
   color: var(--bs-body-color);
+}
+
+.brand-font {
+  font-family: 'Poppins', sans-serif;
 }

--- a/onevision/hosting/index.html
+++ b/onevision/hosting/index.html
@@ -5,12 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>OneVision • 4Credit</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5waTHZ5PZr3QdorE2vLePoHB1zIYd2xt1kxgLZcflBNO8Y+0Y" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <link rel="stylesheet" href="./assets/css/theme.css">
   <link rel="stylesheet" href="./assets/css/bootstrap.custom.css">
 </head>
 <body class="d-flex align-items-center justify-content-center vh-100">
-  <div class="container" style="max-width:400px">
-    <h1 class="text-center mb-4">OneVision • 4Credit</h1>
+  <div class="card p-4 shadow-sm w-100 mx-auto" style="max-width:400px;">
+    <h1 class="text-center mb-4 brand-font"><i class="bi bi-credit-card me-2"></i>OneVision • 4Credit</h1>
     <form id="login-form">
       <div class="mb-3">
         <input type="email" class="form-control" id="email" placeholder="E-mail" required>
@@ -18,8 +19,8 @@
       <div class="mb-3">
         <input type="password" class="form-control" id="password" placeholder="Senha" required>
       </div>
-      <button class="btn btn-primary w-100 mb-2" type="submit">Entrar</button>
-      <button class="btn btn-danger w-100 mb-2" type="button" id="google">Continuar com Google</button>
+      <button class="btn btn-primary w-100 mb-2 brand-font" type="submit"><i class="bi bi-box-arrow-in-right me-2"></i>Entrar</button>
+      <button class="btn btn-danger w-100 mb-2 brand-font" type="button" id="google"><i class="bi bi-google me-2"></i>Continuar com Google</button>
       <div class="d-flex justify-content-between">
         <a href="#" id="signup">Criar conta</a>
         <a href="#" id="reset">Esqueci a senha</a>


### PR DESCRIPTION
## Summary
- center login form inside a Bootstrap card with optional icons
- add Poppins font and gradient background

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68978761588483338ff7fe84b721a9fa