### PR TITLE
Add subtle transitions and fade animations to UI

### DIFF
--- a/onevision/hosting/assets/css/theme.css
+++ b/onevision/hosting/assets/css/theme.css
@@ -63,3 +63,41 @@ body {
   background-color: var(--color-warning-bg) !important;
   color: var(--color-warning-text) !important;
 }
+button,
+input,
+a {
+  transition: all 0.2s ease;
+}
+
+button:hover,
+button:focus {
+  filter: brightness(0.95);
+}
+
+a:hover,
+a:focus {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+input:hover,
+input:focus {
+  box-shadow: 0 0 0 0.2rem rgba(79, 70, 229, 0.25);
+  outline: none;
+}
+
+.fade-in {
+  opacity: 0;
+  animation: fadeIn 0.3s ease forwards;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/onevision/hosting/assets/js/main.js
+++ b/onevision/hosting/assets/js/main.js
@@ -59,7 +59,10 @@ processBtn.addEventListener('click', async () => {
       const meta = await uploadFile(uid, cnpj, type, file);
       const uploadId = await addUpload(cnpj, { ...meta, type, status: 'uploaded' }, uid);
       watchProgress(uid, cnpj, uploadId, snap => {
-        if (snap) progressBar.style.width = snap.percent + '%';
+        if (snap) {
+          progressBar.style.width = snap.percent + '%';
+          progressBar.classList.add('fade-in');
+        }
       });
       const token = await auth.currentUser.getIdToken();
       const res = await fetch('/api/process-file', {
@@ -82,6 +85,7 @@ processBtn.addEventListener('click', async () => {
   } finally {
     setLoading(processBtn, false);
     progressBar.style.width = '0%';
+    progressBar.classList.remove('fade-in');
     updateProcessBtn();
   }
 });
@@ -90,6 +94,7 @@ async function loadReports() {
   if (!currentCNPJ) return;
   const reports = await listReports(currentCNPJ);
   renderReports(reportContainer, reports);
+  Array.from(reportContainer.children).forEach(el => el.classList.add('fade-in'));
 }
 
 document.getElementById('logout').addEventListener('click', () => signOutUser());

--- a/onevision/hosting/assets/js/ui.js
+++ b/onevision/hosting/assets/js/ui.js
@@ -4,7 +4,11 @@ export function showToast(message, type = 'info') {
   toastEl.setAttribute('role', 'alert');
   toastEl.innerHTML = `<div class="d-flex"><div class="toast-body">${message}</div><button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"></button></div>`;
   document.body.appendChild(toastEl);
-  const toast = new bootstrap.Toast(toastEl);
+  const toast = new bootstrap.Toast(toastEl, {
+    animation: true,
+    autohide: true,
+    delay: 3000
+  });
   toast.show();
   toastEl.addEventListener('hidden.bs.toast', () => toastEl.remove());
 }


### PR DESCRIPTION
## Summary
- add transition, hover, and focus styles for buttons, inputs, and links
- refine toast notifications with Bootstrap fade animations and autohide delay
- animate progress updates and report rendering with reusable fade-in class

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68978a87352c8333856623221f4d4172