### PR TITLE
Replace prompt auth flows with Bootstrap modals

### DIFF
--- a/onevision/hosting/assets/js/login.js
+++ b/onevision/hosting/assets/js/login.js
@@ -1,0 +1,78 @@
+import { signInWithEmail, signUpWithEmail, sendPasswordReset, signInWithGoogle } from './auth.js';
+import { showToast } from './ui.js';
+
+const loginForm = document.getElementById('login-form');
+const googleBtn = document.getElementById('google');
+const signupLink = document.getElementById('signup');
+const resetLink = document.getElementById('reset');
+
+const signupModal = new bootstrap.Modal(document.getElementById('signupModal'));
+const resetModal = new bootstrap.Modal(document.getElementById('resetModal'));
+
+loginForm.addEventListener('submit', async e => {
+  e.preventDefault();
+  const email = document.getElementById('email').value;
+  const password = document.getElementById('password').value;
+  try {
+    await signInWithEmail(email, password);
+  } catch (err) {
+    showToast(err.message, 'danger');
+  }
+});
+
+googleBtn.addEventListener('click', async () => {
+  try {
+    await signInWithGoogle();
+  } catch (err) {
+    showToast(err.message, 'danger');
+  }
+});
+
+signupLink.addEventListener('click', e => {
+  e.preventDefault();
+  signupModal.show();
+});
+
+resetLink.addEventListener('click', e => {
+  e.preventDefault();
+  resetModal.show();
+});
+
+// Sign Up form handler
+const signupForm = document.getElementById('signup-form');
+signupForm.addEventListener('submit', async e => {
+  e.preventDefault();
+  if (!signupForm.checkValidity()) {
+    signupForm.reportValidity();
+    return;
+  }
+  const email = document.getElementById('signup-email').value;
+  const password = document.getElementById('signup-password').value;
+  try {
+    await signUpWithEmail(email, password);
+    showToast('Conta criada', 'success');
+    signupModal.hide();
+    signupForm.reset();
+  } catch (err) {
+    showToast(err.message, 'danger');
+  }
+});
+
+// Reset Password form handler
+const resetForm = document.getElementById('reset-form');
+resetForm.addEventListener('submit', async e => {
+  e.preventDefault();
+  if (!resetForm.checkValidity()) {
+    resetForm.reportValidity();
+    return;
+  }
+  const email = document.getElementById('reset-email').value;
+  try {
+    await sendPasswordReset(email);
+    showToast('E-mail enviado', 'success');
+    resetModal.hide();
+    resetForm.reset();
+  } catch (err) {
+    showToast(err.message, 'danger');
+  }
+});

--- a/onevision/hosting/index.html
+++ b/onevision/hosting/index.html
@@ -27,40 +27,57 @@
       </div>
     </form>
   </div>
-  <script type="module">
-    import './assets/js/auth.js';
-    import { signInWithEmail, signUpWithEmail, sendPasswordReset, signInWithGoogle } from './assets/js/auth.js';
-    import { showToast } from './assets/js/ui.js';
 
-    document.getElementById('login-form').addEventListener('submit', async e => {
-      e.preventDefault();
-      const email = document.getElementById('email').value;
-      const password = document.getElementById('password').value;
-      try {
-        await signInWithEmail(email, password);
-      } catch (err) {
-        showToast(err.message, 'danger');
-      }
-    });
-    document.getElementById('google').addEventListener('click', async () => {
-      try { await signInWithGoogle(); } catch (err) { showToast(err.message, 'danger'); }
-    });
-    document.getElementById('signup').addEventListener('click', async e => {
-      e.preventDefault();
-      const email = prompt('E-mail:');
-      const pass = prompt('Senha:');
-      if (email && pass) {
-        try { await signUpWithEmail(email, pass); } catch (err) { showToast(err.message, 'danger'); }
-      }
-    });
-    document.getElementById('reset').addEventListener('click', async e => {
-      e.preventDefault();
-      const email = prompt('E-mail:');
-      if (email) {
-        try { await sendPasswordReset(email); showToast('E-mail enviado', 'success'); } catch (err) { showToast(err.message, 'danger'); }
-      }
-    });
-  </script>
+  <!-- Sign Up Modal -->
+  <div class="modal fade" id="signupModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <form id="signup-form">
+          <div class="modal-header">
+            <h5 class="modal-title">Criar conta</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <div class="mb-3">
+              <input type="email" class="form-control" id="signup-email" placeholder="E-mail" required>
+            </div>
+            <div class="mb-3">
+              <input type="password" class="form-control" id="signup-password" placeholder="Senha" required>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+            <button type="submit" class="btn btn-primary">Cadastrar</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <!-- Reset Password Modal -->
+  <div class="modal fade" id="resetModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <form id="reset-form">
+          <div class="modal-header">
+            <h5 class="modal-title">Recuperar senha</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <div class="mb-3">
+              <input type="email" class="form-control" id="reset-email" placeholder="E-mail" required>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+            <button type="submit" class="btn btn-primary">Enviar</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ENjdO4Dr2bkBIFxQpeoA6zuOM5sV1Kw4nRJ1l6LwVU5MlvI99nN0n0yqmP6X9cOG" crossorigin="anonymous"></script>
+  <script type="module" src="./assets/js/login.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- swap prompt-based account actions for Bootstrap modals in `index.html`
- add `login.js` module to handle modal logic, validation and toast feedback

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_689980452d38833398154c5f01dd56c3