### PR TITLE
Normalize form field sizing in app interface

### DIFF
--- a/onevision/hosting/app.html
+++ b/onevision/hosting/app.html
@@ -16,21 +16,21 @@
   </nav>
   <div class="d-flex">
     <div class="sidebar-modern p-3 border-end">
-      <div class="mb-3">
-        <label class="form-label">CNPJ</label>
-        <input type="text" id="cnpj" class="form-control" placeholder="00.000.000/0000-00">
+      <div class="form-floating">
+        <input type="text" id="cnpj" class="form-control form-control-lg" placeholder="00.000.000/0000-00">
+        <label for="cnpj">CNPJ</label>
       </div>
-      <div class="mb-3">
-        <label class="form-label">VADU</label>
-        <input type="file" id="file-vadu" class="form-control">
+      <div class="input-group">
+        <label class="input-group-text" for="file-vadu">VADU</label>
+        <input type="file" id="file-vadu" class="form-control form-control-lg">
       </div>
-      <div class="mb-3">
-        <label class="form-label">SERASA</label>
-        <input type="file" id="file-serasa" class="form-control">
+      <div class="input-group">
+        <label class="input-group-text" for="file-serasa">SERASA</label>
+        <input type="file" id="file-serasa" class="form-control form-control-lg">
       </div>
-      <div class="mb-3">
-        <label class="form-label">SCR</label>
-        <input type="file" id="file-scr" class="form-control">
+      <div class="input-group">
+        <label class="input-group-text" for="file-scr">SCR</label>
+        <input type="file" id="file-scr" class="form-control form-control-lg">
       </div>
       <button id="process-btn" class="btn btn-primary w-100" disabled>Processar</button>
       <div class="progress mt-2">

--- a/onevision/hosting/assets/css/app.css
+++ b/onevision/hosting/assets/css/app.css
@@ -32,6 +32,13 @@
   transition: width 0.4s ease;
 }
 
+/* Ensure consistent width and spacing for all form groups */
+.form-floating,
+.input-group {
+  width: 100%;
+  margin-bottom: 1rem;
+}
+
 /* Form enhancements for long labels and icons */
 .form-floating > label {
   overflow: hidden;
@@ -39,8 +46,9 @@
   white-space: nowrap;
 }
 
+/* Default padding to maintain uniform field width */
 .form-floating .form-control {
-  padding-left: 2.5rem;
+  padding-left: 1rem;
 }
 
 .form-floating .form-icon {


### PR DESCRIPTION
## Summary
- unify text and file inputs using `form-control form-control-lg` and structured form groups
- ensure consistent width and spacing for form groups in stylesheet

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_6899853049b08333a3e7fd7dee4625e6