### PR TITLE
Refactor auth modals

### DIFF
--- a/onevision/hosting/assets/js/login.js
+++ b/onevision/hosting/assets/js/login.js
@@ -3,11 +3,17 @@ import { showToast } from './ui.js';
 
 const loginForm = document.getElementById('login-form');
 const googleBtn = document.getElementById('google');
-const signupLink = document.getElementById('signup');
-const resetLink = document.getElementById('reset');
-
-const signupModal = new bootstrap.Modal(document.getElementById('signupModal'));
-const resetModal = new bootstrap.Modal(document.getElementById('resetModal'));
+// Handle modal triggers via data attributes
+document.querySelectorAll('[data-bs-toggle="modal"]').forEach(link => {
+  link.addEventListener('click', e => {
+    e.preventDefault();
+    e.stopPropagation();
+    const target = link.getAttribute('data-bs-target');
+    const modalEl = document.querySelector(target);
+    const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
+    modal.show();
+  });
+});
 
 loginForm.addEventListener('submit', async e => {
   e.preventDefault();
@@ -28,16 +34,6 @@ googleBtn.addEventListener('click', async () => {
   }
 });
 
-signupLink.addEventListener('click', e => {
-  e.preventDefault();
-  signupModal.show();
-});
-
-resetLink.addEventListener('click', e => {
-  e.preventDefault();
-  resetModal.show();
-});
-
 // Sign Up form handler
 const signupForm = document.getElementById('signup-form');
 signupForm.addEventListener('submit', async e => {
@@ -51,7 +47,8 @@ signupForm.addEventListener('submit', async e => {
   try {
     await signUpWithEmail(email, password);
     showToast('Conta criada', 'success');
-    signupModal.hide();
+    const modal = bootstrap.Modal.getInstance(document.getElementById('signupModal'));
+    modal.hide();
     signupForm.reset();
   } catch (err) {
     showToast(err.message, 'danger');
@@ -70,7 +67,8 @@ resetForm.addEventListener('submit', async e => {
   try {
     await sendPasswordReset(email);
     showToast('E-mail enviado', 'success');
-    resetModal.hide();
+    const modal = bootstrap.Modal.getInstance(document.getElementById('resetModal'));
+    modal.hide();
     resetForm.reset();
   } catch (err) {
     showToast(err.message, 'danger');

--- a/onevision/hosting/index.html
+++ b/onevision/hosting/index.html
@@ -25,8 +25,8 @@
         <button class="btn btn-primary w-100 mb-2 brand-font" type="submit"><i class="bi bi-box-arrow-in-right me-2"></i>Entrar</button>
         <button class="btn btn-danger w-100 mb-2 brand-font" type="button" id="google"><i class="bi bi-google me-2"></i>Continuar com Google</button>
         <div class="d-flex justify-content-between">
-          <a href="#" id="signup">Criar conta</a>
-          <a href="#" id="reset">Esqueci a senha</a>
+          <a href="#" id="signup" data-bs-toggle="modal" data-bs-target="#signupModal">Criar conta</a>
+          <a href="#" id="reset" data-bs-toggle="modal" data-bs-target="#resetModal">Esqueci a senha</a>
       </div>
     </form>
   </div>


### PR DESCRIPTION
## Summary
- trigger account creation and password reset via Bootstrap modals
- open modals programmatically when links are clicked

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_689986ee0da08333989c3c9dcda7b0d3