### PR TITLE
feat: add utility classes for consistent forms

### DIFF
--- a/onevision/hosting/app.html
+++ b/onevision/hosting/app.html
@@ -12,27 +12,27 @@
 <body class="font-family-base">
   <nav class="navbar navbar-light px-3">
     <span class="navbar-brand mb-0 h1 brand-font">OneVision</span>
-    <button id="logout" class="btn btn-outline-secondary btn-sm">Sair</button>
+    <button id="logout" class="btn btn-standard btn-outline-secondary btn-sm">Sair</button>
   </nav>
   <div class="d-flex">
     <div class="sidebar-modern p-3 border-end">
       <div class="form-floating">
-        <input type="text" id="cnpj" class="form-control form-control-lg" placeholder="00.000.000/0000-00">
+        <input type="text" id="cnpj" class="form-control form-control-lg input-standard" placeholder="00.000.000/0000-00">
         <label for="cnpj">CNPJ</label>
       </div>
       <div class="input-group">
         <label class="input-group-text" for="file-vadu">VADU</label>
-        <input type="file" id="file-vadu" class="form-control form-control-lg">
+        <input type="file" id="file-vadu" class="form-control form-control-lg input-standard">
       </div>
       <div class="input-group">
         <label class="input-group-text" for="file-serasa">SERASA</label>
-        <input type="file" id="file-serasa" class="form-control form-control-lg">
+        <input type="file" id="file-serasa" class="form-control form-control-lg input-standard">
       </div>
       <div class="input-group">
         <label class="input-group-text" for="file-scr">SCR</label>
-        <input type="file" id="file-scr" class="form-control form-control-lg">
+        <input type="file" id="file-scr" class="form-control form-control-lg input-standard">
       </div>
-      <button id="process-btn" class="btn btn-primary w-100" disabled>Processar</button>
+      <button id="process-btn" class="btn btn-standard btn-primary w-100" disabled>Processar</button>
       <div class="progress mt-2">
         <div id="progress-bar" class="progress-bar" role="progressbar"></div>
       </div>

--- a/onevision/hosting/assets/css/theme.css
+++ b/onevision/hosting/assets/css/theme.css
@@ -119,3 +119,18 @@ a:focus {
     transform: translateY(0);
   }
 }
+
+/* Utility classes */
+.input-standard {
+  height: 3rem;
+  padding: 0 var(--space-md);
+  border: 1px solid var(--color-neutral-300);
+  border-radius: 0.5rem;
+}
+
+.btn-standard {
+  min-height: 2.75rem;
+  padding: 0 var(--space-md);
+  border: 1px solid transparent;
+  border-radius: 0.5rem;
+}

--- a/onevision/hosting/index.html
+++ b/onevision/hosting/index.html
@@ -15,15 +15,15 @@
     <h1 class="text-center mb-4 brand-font"><i class="bi bi-credit-card me-2"></i>OneVision • 4Credit</h1>
       <form id="login-form">
         <div class="form-floating mb-3">
-          <input type="email" class="form-control" id="email" placeholder="E-mail" required>
+          <input type="email" class="form-control input-standard" id="email" placeholder="E-mail" required>
           <label for="email">E-mail</label>
         </div>
         <div class="form-floating mb-3">
-          <input type="password" class="form-control" id="password" placeholder="Senha" required>
+          <input type="password" class="form-control input-standard" id="password" placeholder="Senha" required>
           <label for="password">Senha</label>
         </div>
-        <button class="btn btn-primary w-100 mb-2 brand-font" type="submit"><i class="bi bi-box-arrow-in-right me-2"></i>Entrar</button>
-        <button class="btn btn-google w-100 mb-2 brand-font" type="button" id="google">
+        <button class="btn btn-standard btn-primary w-100 mb-2 brand-font" type="submit"><i class="bi bi-box-arrow-in-right me-2"></i>Entrar</button>
+        <button class="btn btn-standard btn-google w-100 mb-2 brand-font" type="button" id="google">
           <img src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg" alt="Google" class="me-2">
           Continuar com Google
         </button>
@@ -45,17 +45,17 @@
           </div>
           <div class="modal-body">
             <div class="form-floating mb-3">
-              <input type="email" class="form-control" id="signup-email" placeholder="E-mail" required>
+              <input type="email" class="form-control input-standard" id="signup-email" placeholder="E-mail" required>
               <label for="signup-email">E-mail</label>
             </div>
             <div class="form-floating mb-3">
-              <input type="password" class="form-control" id="signup-password" placeholder="Senha" required>
+              <input type="password" class="form-control input-standard" id="signup-password" placeholder="Senha" required>
               <label for="signup-password">Senha</label>
             </div>
           </div>
           <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-            <button type="submit" class="btn btn-primary">Cadastrar</button>
+            <button type="button" class="btn btn-standard btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+            <button type="submit" class="btn btn-standard btn-primary">Cadastrar</button>
           </div>
         </form>
       </div>
@@ -73,13 +73,13 @@
           </div>
           <div class="modal-body">
             <div class="form-floating mb-3">
-              <input type="email" class="form-control" id="reset-email" placeholder="E-mail" required>
+              <input type="email" class="form-control input-standard" id="reset-email" placeholder="E-mail" required>
               <label for="reset-email">E-mail</label>
             </div>
           </div>
           <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-            <button type="submit" class="btn btn-primary">Enviar</button>
+            <button type="button" class="btn btn-standard btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+            <button type="submit" class="btn btn-standard btn-primary">Enviar</button>
           </div>
         </form>
       </div>


### PR DESCRIPTION
## Summary
- add reusable input and button utility classes
- apply utility classes to forms in login and app pages

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68998ada953c8333b73f50388667af6c