### PR TITLE
feat: redesign login page with hero and manifesto

### DIFF
--- a/onevision/hosting/index.html
+++ b/onevision/hosting/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>OneVision • 4Credit</title>
+  <title>visionOne • 4Credit</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5waTHZ5PZr3QdorE2vLePoHB1zIYd2xt1kxgLZcflBNO8Y+0Y" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <link rel="stylesheet" href="./assets/css/theme.css">
@@ -11,28 +11,69 @@
   <link rel="stylesheet" href="./assets/css/login.css">
 </head>
 <body class="login-body font-family-base">
-  <div class="card p-4 shadow-sm login-card">
-    <h1 class="text-center mb-4 brand-font"><i class="bi bi-credit-card me-2"></i>OneVision • 4Credit</h1>
-      <form id="login-form">
-        <div class="form-floating">
-          <input type="email" class="form-control input-standard" id="email" placeholder="E-mail" required>
-          <label for="email">E-mail</label>
-        </div>
-        <div class="form-floating">
-          <input type="password" class="form-control input-standard" id="password" placeholder="Senha" required>
-          <label for="password">Senha</label>
-        </div>
-        <button class="btn btn-standard btn-primary w-100 btn-full brand-font" type="submit"><i class="bi bi-box-arrow-in-right me-2"></i>Entrar</button>
-        <button class="btn btn-standard btn-google w-100 btn-full brand-font" type="button" id="google">
-          <img src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg" alt="Google" class="me-2">
-          Continuar com Google
-        </button>
-        <div class="d-flex justify-content-between">
-          <a href="signup.html" id="signup">Criar conta</a>
-          <a href="reset.html" id="reset">Esqueci a senha</a>
-        </div>
-      </form>
-  </div>
+  <main class="login-grid">
+    <section class="login-hero">
+      <div class="brand-bar brand-font with-icon">
+        <i class="bi bi-credit-card"></i>
+        <h1 class="h4 m-0">visionOne • 4Credit</h1>
+      </div>
+      <p class="brand-font">A inteligência que vê o que outros não veem</p>
+    </section>
+    <section>
+      <div class="card p-4 shadow-sm login-card">
+        <h2 class="text-center mb-4 brand-font">Acesse sua conta</h2>
+        <form id="login-form" class="stack-sm">
+          <div class="form-floating">
+            <input type="email" class="form-control input-standard" id="email" placeholder="E-mail" required>
+            <label for="email">E-mail</label>
+          </div>
+          <div class="form-floating">
+            <input type="password" class="form-control input-standard" id="password" placeholder="Senha" required>
+            <label for="password">Senha</label>
+          </div>
+          <button class="btn btn-standard btn-primary w-100 btn-full brand-font with-icon" type="submit">
+            <i class="bi bi-box-arrow-in-right"></i>
+            Entrar
+          </button>
+          <div class="divider"></div>
+          <button class="btn btn-standard btn-google w-100 btn-full brand-font with-icon" type="button" id="google">
+            <img src="https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg" alt="Google">
+            Continuar com Google
+          </button>
+          <div class="d-flex justify-content-between">
+            <a href="signup.html" id="signup">Criar conta</a>
+            <a href="reset.html" id="reset">Esqueci a senha</a>
+          </div>
+        </form>
+      </div>
+    </section>
+  </main>
+
+  <section id="manifesto" class="manifesto-section brand-font mt-4 container">
+    <h2 class="mb-4 text-center">Manifesto Visão N1 – A Inteligência que Lê o Comportamento</h2>
+    <p>O mercado de crédito ainda se guia, majoritariamente, por números soltos: score, rating, balanços.</p>
+    <p>Mas crédito não é só matemática. Crédito é comportamento sob contingência.</p>
+    <p>Na 4CREDIT, acreditamos que a melhor forma de prever o comportamento de uma empresa no futuro é compreender como ela se comportou no passado — especialmente sob pressão, em risco, diante de decisões críticas.</p>
+    <p>Foi assim que criamos os Relatórios N1 e RN1.</p>
+    <p>Mais que documentos, eles são uma metodologia de leitura funcional da conduta empresarial:</p>
+    <ul>
+      <li>Como essa empresa responde à pressão de caixa?</li>
+      <li>Como age quando enfrenta litígios, endividamento ou consultas financeiras frequentes?</li>
+      <li>Como interage com o sistema de crédito ao longo do tempo?</li>
+    </ul>
+    <p>Essas perguntas não cabem num score. Mas nós já sabemos como respondê-las.</p>
+    <p>Com base em análise comportamental, padrões históricos e lógica preditiva, desenvolvemos uma metodologia própria. Validada. Aplicada. Repetida.</p>
+    <p>E agora, pronta para escalar.</p>
+    <p>A Visão N1 é mais do que um relatório. É a base para uma nova geração de inteligência de crédito — onde comportamento, histórico e contexto se unem para antecipar risco com profundidade.</p>
+    <p>A Visão N1 pode ser:</p>
+    <ul>
+      <li>Um parceiro estratégico para estruturas como bancos, FIDCs e securitizadoras.</li>
+      <li>Um instrumento acessível para qualquer empresa que vende a prazo e precisa decidir com quem negociar.</li>
+      <li>E, sobretudo, uma arquitetura replicável de IA preditiva, capaz de aprender a enxergar o que hoje só olhos experientes percebem.</li>
+    </ul>
+    <p>Nossa missão é simples:<br>Tornar o crédito mais justo, mais inteligente e mais previsível — com base em comportamento, não em achismos.</p>
+    <p>Essa é a Visão N1.<br>A inteligência que vê o que outros não veem</p>
+  </section>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ENjdO4Dr2bkBIFxQpeoA6zuOM5sV1Kw4nRJ1l6LwVU5MlvI99nN0n0yqmP6X9cOG" crossorigin="anonymous"></script>
   <script type="module" src="./assets/js/login.js"></script>


### PR DESCRIPTION
## Summary
- overhaul login layout with hero and grid sections
- remove legacy margin classes in favor of `.with-icon`
- include manifesto section after login grid and update title

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a7e9a2f90c833386d44bd4b0a410e7