### PR TITLE
Update signup page branding

### DIFF
--- a/onevision/hosting/assets/img/visionone.svg
+++ b/onevision/hosting/assets/img/visionone.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 24">
+  <text x="0" y="18" font-family="Arial, sans-serif" font-size="18">visionOne</text>
+</svg>

--- a/onevision/hosting/signup.html
+++ b/onevision/hosting/signup.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>OneVision • Cadastro</title>
+  <title>visionOne • Cadastro</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5waTHZ5PZr3QdorE2vLePoHB1zIYd2xt1kxgLZcflBNO8Y+0Y" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <link rel="stylesheet" href="./assets/css/theme.css">
@@ -12,7 +12,11 @@
 </head>
 <body class="login-body font-family-base">
   <div class="card p-4 shadow-sm login-card">
-    <h1 class="text-center mb-4 brand-font"><i class="bi bi-credit-card me-2"></i>OneVision • 4Credit</h1>
+    <div class="brand-bar">
+      <img src="./assets/img/visionone.svg" class="brand-logo">
+      <span class="brand-font h5 m-0">visionOne • 4Credit</span>
+    </div>
+    <h2 class="text-center mb-4 brand-font">Criar conta</h2>
     <form id="signup-form">
       <div class="form-floating mb-3">
         <input type="email" class="form-control input-standard" id="signup-email" placeholder="E-mail" required>


### PR DESCRIPTION
## Summary
- revise signup `<title>` to visionOne • Cadastro
- swap heading for brand bar with logo and add page title
- add placeholder visionOne logo asset

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a7eb589ba88333a8d57e0d77ad3f28