### PR TITLE
Update reset page branding

### DIFF
--- a/onevision/hosting/reset.html
+++ b/onevision/hosting/reset.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>OneVision • Recuperar senha</title>
+  <title>visionOne • Recuperar senha</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5waTHZ5PZr3QdorE2vLePoHB1zIYd2xt1kxgLZcflBNO8Y+0Y" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <link rel="stylesheet" href="./assets/css/theme.css">
@@ -11,9 +11,13 @@
   <link rel="stylesheet" href="./assets/css/login.css">
 </head>
 <body class="login-body font-family-base">
-  <div class="card p-4 shadow-sm login-card">
-    <h1 class="text-center mb-4 brand-font"><i class="bi bi-credit-card me-2"></i>OneVision • 4Credit</h1>
-    <form id="reset-form">
+    <div class="card p-4 shadow-sm login-card">
+      <div class="brand-bar brand-font with-icon">
+        <i class="bi bi-credit-card"></i>
+        <h1 class="h4 m-0">visionOne • 4Credit</h1>
+      </div>
+      <h2 class="brand-font">Recuperar senha</h2>
+      <form id="reset-form">
       <div class="form-floating mb-3">
         <input type="email" class="form-control input-standard" id="reset-email" placeholder="E-mail" required>
         <label for="reset-email">E-mail</label>


### PR DESCRIPTION
## Summary
- update reset page title to "visionOne" branding
- replace password reset heading with brand bar from login page
- add page heading for password recovery

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_b_68a7ec5208dc8333abfc210b2d40ba95