### PR TITLE
Refine app page layout with icons and responsive sidebar

### DIFF
--- a/onevision/hosting/app.html
+++ b/onevision/hosting/app.html
@@ -3,43 +3,53 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>OneVision • App</title>
+  <title>visionOne • App</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5waTHZ5PZr3QdorE2vLePoHB1zIYd2xt1kxgLZcflBNO8Y+0Y" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <link rel="stylesheet" href="./assets/css/theme.css">
   <link rel="stylesheet" href="./assets/css/bootstrap.custom.css">
   <link rel="stylesheet" href="./assets/css/app.css">
 </head>
 <body class="font-family-base">
   <nav class="navbar navbar-light px-3">
-    <span class="navbar-brand mb-0 h1 brand-font">OneVision</span>
-    <button id="logout" class="btn btn-standard btn-outline-secondary btn-sm">Sair</button>
+    <span class="navbar-brand mb-0 h1 brand-font with-icon">
+      <img src="./assets/img/visionone.svg" alt="visionOne" height="32">
+      <span>visionOne</span>
+    </span>
+    <button id="logout" class="btn btn-standard btn-outline-secondary btn-sm with-icon">
+      <i class="bi bi-box-arrow-right"></i>
+      <span>Sair</span>
+    </button>
   </nav>
-  <div class="d-flex">
-    <div class="sidebar-modern p-3 border-end">
+  <div class="d-flex gap-3 container py-3">
+    <aside class="sidebar-modern">
       <div class="form-floating">
         <input type="text" id="cnpj" class="form-control form-control-lg input-standard" placeholder="00.000.000/0000-00">
         <label for="cnpj">CNPJ</label>
       </div>
-      <label class="btn btn-standard btn-outline-secondary upload-btn">
-        VADU
+      <label class="btn btn-standard btn-outline-secondary upload-btn with-icon">
+        <i class="bi bi-file-earmark-text"></i>
+        <span>VADU</span>
         <input type="file" id="file-vadu" hidden>
       </label>
-      <label class="btn btn-standard btn-outline-secondary upload-btn">
-        SERASA
+      <label class="btn btn-standard btn-outline-secondary upload-btn with-icon">
+        <i class="bi bi-building"></i>
+        <span>SERASA</span>
         <input type="file" id="file-serasa" hidden>
       </label>
-      <label class="btn btn-standard btn-outline-secondary upload-btn">
-        SCR
+      <label class="btn btn-standard btn-outline-secondary upload-btn with-icon">
+        <i class="bi bi-bank"></i>
+        <span>SCR</span>
         <input type="file" id="file-scr" hidden>
       </label>
       <button id="process-btn" class="btn btn-standard btn-primary w-100" disabled>Processar</button>
-      <div class="progress mt-2">
+      <div class="progress mt-2" style="height: 6px;">
         <div id="progress-bar" class="progress-bar" role="progressbar"></div>
       </div>
-    </div>
-    <div class="flex-grow-1 p-3">
+    </aside>
+    <main class="flex-grow-1">
       <div id="reports"></div>
-    </div>
+    </main>
   </div>
   <section id="manifesto" class="manifesto-section brand-font mt-4 container">
     <h2 class="mb-4 text-center">Manifesto Visão N1 – A Inteligência que Lê o Comportamento</h2>

--- a/onevision/hosting/assets/css/app.css
+++ b/onevision/hosting/assets/css/app.css
@@ -26,7 +26,7 @@
 }
 
 #progress-bar {
-  height: 4px;
+  height: 100%;
   width: 0;
   background-color: #0d6efd;
   transition: width 0.4s ease;


### PR DESCRIPTION
## Summary
- restyle navbar with logo brand and icon-augmented logout button
- add container/aside/main layout and iconized upload buttons
- tweak progress bar markup and CSS height handling

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a7ef9d1e748333ba8e0d005b69b75e