### PR TITLE
feat: add visionOne brand logo

### DIFF
--- a/onevision/hosting/app.html
+++ b/onevision/hosting/app.html
@@ -13,7 +13,7 @@
 <body class="font-family-base">
   <nav class="navbar navbar-light px-3">
     <span class="navbar-brand mb-0 h1 brand-font with-icon">
-      <img src="./assets/img/visionone.svg" alt="visionOne" height="32">
+      <img src="./assets/img/visionone.svg" class="brand-logo" alt="visionOne">
       <span>visionOne</span>
     </span>
     <button id="logout" class="btn btn-standard btn-outline-secondary btn-sm with-icon">

--- a/onevision/hosting/assets/css/login.css
+++ b/onevision/hosting/assets/css/login.css
@@ -35,7 +35,7 @@ body {
 }
 
 .brand-logo {
-  height: 3rem;
+  height: 36px;
 }
 
 .login-card {

--- a/onevision/hosting/assets/img/visionone.svg
+++ b/onevision/hosting/assets/img/visionone.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 24">
+<svg xmlns="http://www.w3.org/2000/svg" width="180" height="36" viewBox="0 0 120 24">
   <text x="0" y="18" font-family="Arial, sans-serif" font-size="18">visionOne</text>
 </svg>

--- a/onevision/hosting/signup.html
+++ b/onevision/hosting/signup.html
@@ -13,7 +13,7 @@
 <body class="login-body font-family-base">
   <div class="card p-4 shadow-sm login-card">
     <div class="brand-bar">
-      <img src="./assets/img/visionone.svg" class="brand-logo">
+      <img src="./assets/img/visionone.svg" class="brand-logo" alt="visionOne">
       <span class="brand-font h5 m-0">visionOne • 4Credit</span>
     </div>
     <h2 class="text-center mb-4 brand-font">Criar conta</h2>


### PR DESCRIPTION
## Summary
- size visionOne SVG logo to 36px tall
- use consistent brand logo markup across pages
- style brand logo height

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a7f25ae83483338bef2d2366367ac6