### PR TITLE
Standardize visionOne branding

### DIFF
--- a/onevision/hosting/app.html
+++ b/onevision/hosting/app.html
@@ -14,7 +14,7 @@
   <nav class="navbar navbar-light px-3">
     <span class="navbar-brand mb-0 h1 brand-font with-icon">
       <img src="./assets/img/visionone.svg" class="brand-logo" alt="visionOne">
-      <span>visionOne</span>
+      <span>visionOne • App</span>
     </span>
     <button id="logout" class="btn btn-standard btn-outline-secondary btn-sm with-icon">
       <i class="bi bi-box-arrow-right"></i>

--- a/onevision/hosting/reset.html
+++ b/onevision/hosting/reset.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>visionOne • Recuperar senha</title>
+  <title>visionOne • 4Credit</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5waTHZ5PZr3QdorE2vLePoHB1zIYd2xt1kxgLZcflBNO8Y+0Y" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <link rel="stylesheet" href="./assets/css/theme.css">

--- a/onevision/hosting/signup.html
+++ b/onevision/hosting/signup.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>visionOne • Cadastro</title>
+  <title>visionOne • 4Credit</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5waTHZ5PZr3QdorE2vLePoHB1zIYd2xt1kxgLZcflBNO8Y+0Y" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <link rel="stylesheet" href="./assets/css/theme.css">


### PR DESCRIPTION
## Summary
- Rename signup and password reset page titles to "visionOne • 4Credit"
- Show "visionOne • App" in the application navbar

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a7f37b86b48333943cc6ec3cb5e49b