### PR TITLE
feat: add responsive navbar and separate manifesto page

### DIFF
--- a/onevision/hosting/app.html
+++ b/onevision/hosting/app.html
@@ -12,16 +12,31 @@
   <link rel="icon" type="image/png" href="./thumbnail.png">
 </head>
 <body class="font-family-base">
-  <nav class="navbar navbar-light px-3">
-    <span class="navbar-brand mb-0 h1 brand-font with-icon">
-      <img src="./assets/img/visionone.svg" class="brand-logo" alt="visionOne">
-      <span>visionOne • App</span>
-    </span>
-    <button id="logout" class="btn btn-standard btn-outline-secondary btn-sm with-icon">
-      <i class="bi bi-box-arrow-right"></i>
-      <span>Sair</span>
-    </button>
-  </nav>
+  <header>
+    <nav class="navbar navbar-expand-lg navbar-light px-3">
+      <a class="navbar-brand mb-0 h1 brand-font with-icon" href="app.html">
+        <img src="./assets/img/visionone.svg" class="brand-logo" alt="visionOne">
+        <span>visionOne • App</span>
+      </a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNavbar" aria-controls="mainNavbar" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="mainNavbar">
+        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+          <li class="nav-item">
+            <a class="nav-link" href="app.html">Dashboard</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="manifesto.html">Manifesto</a>
+          </li>
+        </ul>
+        <button id="logout" class="btn btn-standard btn-outline-secondary btn-sm with-icon">
+          <i class="bi bi-box-arrow-right"></i>
+          <span>Sair</span>
+        </button>
+      </div>
+    </nav>
+  </header>
   <div class="d-flex gap-3 container py-3">
     <aside class="sidebar-modern">
       <div class="form-floating">
@@ -52,31 +67,6 @@
       <div id="reports"></div>
     </main>
   </div>
-  <section id="manifesto" class="manifesto-section brand-font mt-4 container">
-    <h2 class="mb-4 text-center">Manifesto Visão N1 – A Inteligência que Lê o Comportamento</h2>
-    <p>O mercado de crédito ainda se guia, majoritariamente, por números soltos: score, rating, balanços.</p>
-    <p>Mas crédito não é só matemática. Crédito é comportamento sob contingência.</p>
-    <p>Na 4CREDIT, acreditamos que a melhor forma de prever o comportamento de uma empresa no futuro é compreender como ela se comportou no passado — especialmente sob pressão, em risco, diante de decisões críticas.</p>
-    <p>Foi assim que criamos os Relatórios N1 e RN1.</p>
-    <p>Mais que documentos, eles são uma metodologia de leitura funcional da conduta empresarial:</p>
-    <ul>
-      <li>Como essa empresa responde à pressão de caixa?</li>
-      <li>Como age quando enfrenta litígios, endividamento ou consultas financeiras frequentes?</li>
-      <li>Como interage com o sistema de crédito ao longo do tempo?</li>
-    </ul>
-    <p>Essas perguntas não cabem num score. Mas nós já sabemos como respondê-las.</p>
-    <p>Com base em análise comportamental, padrões históricos e lógica preditiva, desenvolvemos uma metodologia própria. Validada. Aplicada. Repetida.</p>
-    <p>E agora, pronta para escalar.</p>
-    <p>A Visão N1 é mais do que um relatório. É a base para uma nova geração de inteligência de crédito — onde comportamento, histórico e contexto se unem para antecipar risco com profundidade.</p>
-    <p>A Visão N1 pode ser:</p>
-    <ul>
-      <li>Um parceiro estratégico para estruturas como bancos, FIDCs e securitizadoras.</li>
-      <li>Um instrumento acessível para qualquer empresa que vende a prazo e precisa decidir com quem negociar.</li>
-      <li>E, sobretudo, uma arquitetura replicável de IA preditiva, capaz de aprender a enxergar o que hoje só olhos experientes percebem.</li>
-    </ul>
-    <p>Nossa missão é simples:<br>Tornar o crédito mais justo, mais inteligente e mais previsível — com base em comportamento, não em achismos.</p>
-    <p>Essa é a Visão N1.<br>A inteligência que vê o que outros não veem</p>
-  </section>
   <script type="module" src="./assets/js/auth.js"></script>
   <script type="module" src="./assets/js/main.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ENjdO4Dr2bkBIFxQpeoA6zuOM5sV1Kw4nRJ1l6LwVU5MlvI99nN0n0yqmP6X9cOG" crossorigin="anonymous"></script>

--- a/onevision/hosting/assets/css/app.css
+++ b/onevision/hosting/assets/css/app.css
@@ -4,6 +4,24 @@
   font-weight: 600;
 }
 
+.navbar .navbar-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.navbar .nav-link {
+  color: var(--color-neutral-900);
+}
+
+.navbar .nav-link:hover {
+  color: var(--color-primary);
+}
+
+.navbar-toggler {
+  border: none;
+}
+
 .sidebar-modern {
   flex: 1 1 240px;
   min-width: 200px;

--- a/onevision/hosting/manifesto.html
+++ b/onevision/hosting/manifesto.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="pt-br">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>visionOne • Manifesto</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5waTHZ5PZr3QdorE2vLePoHB1zIYd2xt1kxgLZcflBNO8Y+0Y" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="./assets/css/theme.css">
+  <link rel="stylesheet" href="./assets/css/bootstrap.custom.css">
+  <link rel="stylesheet" href="./assets/css/app.css">
+  <link rel="icon" type="image/png" href="./thumbnail.png">
+</head>
+<body class="font-family-base">
+  <header>
+    <nav class="navbar navbar-expand-lg navbar-light px-3">
+      <a class="navbar-brand mb-0 h1 brand-font with-icon" href="app.html">
+        <img src="./assets/img/visionone.svg" class="brand-logo" alt="visionOne">
+        <span>visionOne • App</span>
+      </a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNavbar" aria-controls="mainNavbar" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="mainNavbar">
+        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+          <li class="nav-item">
+            <a class="nav-link" href="app.html">Dashboard</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link active" aria-current="page" href="manifesto.html">Manifesto</a>
+          </li>
+        </ul>
+        <button id="logout" class="btn btn-standard btn-outline-secondary btn-sm with-icon">
+          <i class="bi bi-box-arrow-right"></i>
+          <span>Sair</span>
+        </button>
+      </div>
+    </nav>
+  </header>
+  <main id="manifesto" class="manifesto-section brand-font mt-4 container">
+    <h2 class="mb-4 text-center">Manifesto Visão N1 – A Inteligência que Lê o Comportamento</h2>
+    <p>O mercado de crédito ainda se guia, majoritariamente, por números soltos: score, rating, balanços.</p>
+    <p>Mas crédito não é só matemática. Crédito é comportamento sob contingência.</p>
+    <p>Na 4CREDIT, acreditamos que a melhor forma de prever o comportamento de uma empresa no futuro é compreender como ela se comportou no passado — especialmente sob pressão, em risco, diante de decisões críticas.</p>
+    <p>Foi assim que criamos os Relatórios N1 e RN1.</p>
+    <p>Mais que documentos, eles são uma metodologia de leitura funcional da conduta empresarial:</p>
+    <ul>
+      <li>Como essa empresa responde à pressão de caixa?</li>
+      <li>Como age quando enfrenta litígios, endividamento ou consultas financeiras frequentes?</li>
+      <li>Como interage com o sistema de crédito ao longo do tempo?</li>
+    </ul>
+    <p>Essas perguntas não cabem num score. Mas nós já sabemos como respondê-las.</p>
+    <p>Com base em análise comportamental, padrões históricos e lógica preditiva, desenvolvemos uma metodologia própria. Validada. Aplicada. Repetida.</p>
+    <p>E agora, pronta para escalar.</p>
+    <p>A Visão N1 é mais do que um relatório. É a base para uma nova geração de inteligência de crédito — onde comportamento, histórico e contexto se unem para antecipar risco com profundidade.</p>
+    <p>A Visão N1 pode ser:</p>
+    <ul>
+      <li>Um parceiro estratégico para estruturas como bancos, FIDCs e securitizadoras.</li>
+      <li>Um instrumento acessível para qualquer empresa que vende a prazo e precisa decidir com quem negociar.</li>
+      <li>E, sobretudo, uma arquitetura replicável de IA preditiva, capaz de aprender a enxergar o que hoje só olhos experientes percebem.</li>
+    </ul>
+    <p>Nossa missão é simples:<br>Tornar o crédito mais justo, mais inteligente e mais previsível — com base em comportamento, não em achismos.</p>
+    <p>Essa é a Visão N1.<br>A inteligência que vê o que outros não veem</p>
+  </main>
+  <script type="module">
+    import { signOutUser } from './assets/js/auth.js';
+    document.getElementById('logout').addEventListener('click', () => signOutUser());
+  </script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ENjdO4Dr2bkBIFxQpeoA6zuOM5sV1Kw4nRJ1l6LwVU5MlvI99nN0n0yqmP6X9cOG" crossorigin="anonymous"></script>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- replace top nav with responsive Bootstrap header
- move manifesto content to new page and link from navbar
- style new header and menu elements

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a7fde49840833384d9d95cf8c47057