### PR TITLE
chore: remove VisionOne PNG asset

### DIFF
--- a/onevision/hosting/app.html
+++ b/onevision/hosting/app.html
@@ -9,13 +9,13 @@
   <link rel="stylesheet" href="./assets/css/theme.css">
   <link rel="stylesheet" href="./assets/css/bootstrap.custom.css">
   <link rel="stylesheet" href="./assets/css/app.css">
-  <link rel="icon" type="image/png" href="./thumbnail.png">
+    <link rel="icon" type="image/svg+xml" href="./assets/img/visionone.svg">
 </head>
 <body class="font-family-base">
   <header>
     <nav class="navbar navbar-expand-lg navbar-light px-3">
       <a class="navbar-brand mb-0 h1 brand-font with-icon" href="app.html">
-        <img src="./assets/img/visionone.svg" class="brand-logo" alt="visionOne">
+          <img src="./assets/img/visionone.svg" class="brand-logo" alt="VisionOne Credit Risk">
         <span>visionOne • App</span>
       </a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNavbar" aria-controls="mainNavbar" aria-expanded="false" aria-label="Toggle navigation">

--- a/onevision/hosting/index.html
+++ b/onevision/hosting/index.html
@@ -9,13 +9,13 @@
   <link rel="stylesheet" href="./assets/css/theme.css">
   <link rel="stylesheet" href="./assets/css/bootstrap.custom.css">
   <link rel="stylesheet" href="./assets/css/login.css">
-  <link rel="icon" type="image/png" href="./thumbnail.png">
+    <link rel="icon" type="image/svg+xml" href="./assets/img/visionone.svg">
 </head>
 <body class="login-body font-family-base">
   <main class="login-grid">
     <section class="login-hero">
       <div class="brand-bar brand-font with-icon">
-        <img src="./thumbnail.png" class="brand-logo" alt="4Credit">
+          <img src="./assets/img/visionone.svg" class="brand-logo" alt="VisionOne Credit Risk">
         <h1 class="h4 m-0">visionOne • 4Credit</h1>
       </div>
       <p class="brand-font">A inteligência que vê o que outros não veem</p>

--- a/onevision/hosting/manifesto.html
+++ b/onevision/hosting/manifesto.html
@@ -9,13 +9,13 @@
   <link rel="stylesheet" href="./assets/css/theme.css">
   <link rel="stylesheet" href="./assets/css/bootstrap.custom.css">
   <link rel="stylesheet" href="./assets/css/app.css">
-  <link rel="icon" type="image/png" href="./thumbnail.png">
+    <link rel="icon" type="image/svg+xml" href="./assets/img/visionone.svg">
 </head>
 <body class="font-family-base">
   <header>
     <nav class="navbar navbar-expand-lg navbar-light px-3">
       <a class="navbar-brand mb-0 h1 brand-font with-icon" href="app.html">
-        <img src="./assets/img/visionone.svg" class="brand-logo" alt="visionOne">
+          <img src="./assets/img/visionone.svg" class="brand-logo" alt="VisionOne Credit Risk">
         <span>visionOne • App</span>
       </a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNavbar" aria-controls="mainNavbar" aria-expanded="false" aria-label="Toggle navigation">

--- a/onevision/hosting/reset.html
+++ b/onevision/hosting/reset.html
@@ -8,14 +8,15 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <link rel="stylesheet" href="./assets/css/theme.css">
   <link rel="stylesheet" href="./assets/css/bootstrap.custom.css">
-  <link rel="stylesheet" href="./assets/css/login.css">
-</head>
+    <link rel="stylesheet" href="./assets/css/login.css">
+    <link rel="icon" type="image/svg+xml" href="./assets/img/visionone.svg">
+  </head>
 <body class="login-body font-family-base">
     <div class="card p-4 shadow-sm login-card">
-      <div class="brand-bar brand-font with-icon">
-        <i class="bi bi-credit-card"></i>
-        <h1 class="h4 m-0">visionOne • 4Credit</h1>
-      </div>
+        <div class="brand-bar brand-font with-icon">
+          <img src="./assets/img/visionone.svg" class="brand-logo" alt="VisionOne Credit Risk">
+          <h1 class="h4 m-0">visionOne • 4Credit</h1>
+        </div>
       <h2 class="brand-font">Recuperar senha</h2>
       <form id="reset-form">
       <div class="form-floating mb-3">

--- a/onevision/hosting/signup.html
+++ b/onevision/hosting/signup.html
@@ -8,12 +8,13 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <link rel="stylesheet" href="./assets/css/theme.css">
   <link rel="stylesheet" href="./assets/css/bootstrap.custom.css">
-  <link rel="stylesheet" href="./assets/css/login.css">
+    <link rel="stylesheet" href="./assets/css/login.css">
+    <link rel="icon" type="image/svg+xml" href="./assets/img/visionone.svg">
 </head>
 <body class="login-body font-family-base">
   <div class="card p-4 shadow-sm login-card">
     <div class="brand-bar">
-      <img src="./assets/img/visionone.svg" class="brand-logo" alt="visionOne">
+        <img src="./assets/img/visionone.svg" class="brand-logo" alt="VisionOne Credit Risk">
       <span class="brand-font h5 m-0">visionOne • 4Credit</span>
     </div>
     <h2 class="text-center mb-4 brand-font">Criar conta</h2>


### PR DESCRIPTION
## Summary
- use visionone.svg for favicon and brand logo across pages
- remove visionone.png binary asset

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_b_68a87282e0148333a8df63a1b77c781b