### PR TITLE
Unificar branding e layout de signup e reset

### DIFF
--- a/onevision/hosting/assets/css/login.css
+++ b/onevision/hosting/assets/css/login.css
@@ -28,9 +28,6 @@ body {
 }
 
 .brand-bar {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
   margin-bottom: 2rem;
 }
 

--- a/onevision/hosting/reset.html
+++ b/onevision/hosting/reset.html
@@ -13,11 +13,12 @@
   </head>
 <body class="login-body font-family-base">
     <div class="card p-4 shadow-sm login-card">
-        <div class="brand-bar brand-font with-icon">
-          <img src="./assets/img/visionone.svg" class="brand-logo" alt="VisionOne Credit Risk">
-          <h1 class="h4 m-0">visionOne • 4Credit</h1>
+        <div class="brand-bar with-icon brand-font">
+          <img src="./assets/img/visionone.png" class="brand-logo" alt="VisionOne Credit Risk">
+          <h1 class="h5 m-0">VisionOne • 4Credit</h1>
         </div>
       <h2 class="brand-font">Recuperar senha</h2>
+      <p class="mb-4">Enviaremos instruções para o seu e-mail</p>
       <form id="reset-form">
       <div class="form-floating mb-3">
         <input type="email" class="form-control input-standard" id="reset-email" placeholder="E-mail" required>

--- a/onevision/hosting/signup.html
+++ b/onevision/hosting/signup.html
@@ -13,9 +13,9 @@
 </head>
 <body class="login-body font-family-base">
   <div class="card p-4 shadow-sm login-card">
-    <div class="brand-bar">
-        <img src="./assets/img/visionone.svg" class="brand-logo" alt="VisionOne Credit Risk">
-      <span class="brand-font h5 m-0">visionOne • 4Credit</span>
+    <div class="brand-bar with-icon brand-font">
+      <img src="./assets/img/visionone.png" class="brand-logo" alt="VisionOne Credit Risk">
+      <h1 class="h5 m-0">VisionOne • 4Credit</h1>
     </div>
     <h2 class="text-center mb-4 brand-font">Criar conta</h2>
     <form id="signup-form">


### PR DESCRIPTION
## Summary
- Reuse brand bar on signup/reset pages with VisionOne logo and title
- Add reset microcopy guiding users to email instructions
- Simplify brand bar styling to rely on shared spacing classes

## Testing
- ⚠️ `npm test` (missing script: "test")

------
https://chatgpt.com/codex/tasks/task_b_68a879a023888333bfdfd1654c13889a