### PR TITLE
feat: add VisionOne sidebar navigation

### DIFF
--- a/onevision/hosting/app.html
+++ b/onevision/hosting/app.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>visionOne • App</title>
+    <title>VisionOne • App</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5waTHZ5PZr3QdorE2vLePoHB1zIYd2xt1kxgLZcflBNO8Y+0Y" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <link rel="stylesheet" href="./assets/css/theme.css">
@@ -15,8 +15,8 @@
   <header>
     <nav class="navbar navbar-expand-lg navbar-light px-3">
       <a class="navbar-brand mb-0 h1 brand-font with-icon" href="app.html">
-          <img src="./assets/img/visionone.svg" class="brand-logo" alt="VisionOne Credit Risk">
-        <span>visionOne • App</span>
+          <img src="./assets/img/visionone.svg" class="brand-logo" alt="VisionOne">
+        <span>VisionOne • App</span>
       </a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNavbar" aria-controls="mainNavbar" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
@@ -39,6 +39,16 @@
   </header>
   <div class="d-flex gap-3 container py-3">
     <aside class="sidebar-modern">
+      <nav class="sidebar-nav mb-3">
+        <a class="sidebar-item active with-icon" href="app.html"><i class="bi bi-house"></i> Início</a>
+        <a class="sidebar-item with-icon" href="#"><i class="bi bi-building"></i> Empresas</a>
+        <a class="sidebar-item with-icon" href="#"><i class="bi bi-file-earmark-text"></i> Relatórios</a>
+        <a class="sidebar-item with-icon" href="#"><i class="bi bi-bell"></i> Alertas</a>
+        <a class="sidebar-item with-icon" href="#"><i class="bi bi-gear"></i> Regras</a>
+        <a class="sidebar-item with-icon" href="#"><i class="bi bi-plug"></i> Integrações</a>
+        <a class="sidebar-item with-icon" href="#"><i class="bi bi-shield-lock"></i> Admin & LGPD</a>
+      </nav>
+      <hr>
       <div class="form-floating">
         <input type="text" id="cnpj" class="form-control form-control-lg input-standard" placeholder="00.000.000/0000-00">
         <label for="cnpj">CNPJ</label>

--- a/onevision/hosting/assets/css/app.css
+++ b/onevision/hosting/assets/css/app.css
@@ -85,11 +85,32 @@
   padding-left: 1rem;
 }
 
-.form-floating .form-icon {
-  position: absolute;
-  top: 50%;
-  left: 0.75rem;
-  transform: translateY(-50%);
-  pointer-events: none;
-  font-size: 1rem;
-}
+  .form-floating .form-icon {
+    position: absolute;
+    top: 50%;
+    left: 0.75rem;
+    transform: translateY(-50%);
+    pointer-events: none;
+    font-size: 1rem;
+  }
+
+  .sidebar-nav{
+    background:var(--color-primary-900);
+    border-radius:var(--radius-lg);
+    padding:.5rem;
+  }
+  .sidebar-item{
+    display:flex;
+    align-items:center;
+    gap:.5rem;
+    color:#fff;
+    padding:.5rem .75rem;
+    border-radius:8px;
+    text-decoration:none;
+  }
+  .sidebar-item:hover{
+    background:rgba(255,255,255,.08);
+  }
+  .sidebar-item.active{
+    background:rgba(255,255,255,.15);
+  }


### PR DESCRIPTION
## Summary
- update navbar branding to "VisionOne • App" with new logo
- add VisionOne navigation menu to sidebar and adjust layout
- style sidebar navigation items for VisionOne look

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a87a790d3883339df1c66cfbe4caf7