### PR TITLE
feat: add severity chip to report cards

### DIFF
--- a/onevision/hosting/assets/js/reports.view.js
+++ b/onevision/hosting/assets/js/reports.view.js
@@ -10,13 +10,14 @@ export function renderReports(container, reports) {
     const card = document.createElement('div');
     card.className = 'card card-elevated mb-2';
     const date = r.generatedAt?.toDate ? r.generatedAt.toDate() : new Date(r.generatedAt);
+    const sev = r.severity ? `<span class="chip ${r.severity === 'critical' ? 'neg' : 'pos'}">${r.severity}</span>` : '';
     card.innerHTML = `
       <div class="card-body">
-        <div class="d-flex justify-content-between">
-          <h6 class="brand-font">${r.type}</h6>
-          <small>${date.toLocaleString()}</small>
+        <div class="d-flex justify-content-between align-items-center mb-1">
+          <h6 class="brand-font m-0 with-icon"><i class="bi bi-file-earmark-text"></i> ${r.type} ${sev}</h6>
+          <small class="text-muted">${date.toLocaleString()}</small>
         </div>
-        <p>${r.summary}</p>
+        <p class="mb-0">${r.summary ?? ''}</p>
       </div>`;
     container.appendChild(card);
   });


### PR DESCRIPTION
## Summary
- display severity chips in reports when available
- wrap report title and timestamp for improved layout

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a87ba31e1083338caf6e40ca287c81