### PR TITLE
feat: enhance error handling and loading states

### DIFF
--- a/onevision/hosting/assets/js/login.js
+++ b/onevision/hosting/assets/js/login.js
@@ -1,5 +1,5 @@
 import { signInWithEmail, signUpWithEmail, sendPasswordReset, signInWithGoogle } from './auth.js';
-import { showToast } from './ui.js';
+import { showToast, setLoading, handleError } from './ui.js';
 
 const loginForm = document.getElementById('login-form');
 const googleBtn = document.getElementById('google');
@@ -9,12 +9,16 @@ const requestAccess = document.getElementById('request-access');
 if (loginForm) {
   loginForm.addEventListener('submit', async e => {
     e.preventDefault();
+    const btn = loginForm.querySelector('button[type="submit"]');
     const email = document.getElementById('email').value;
     const password = document.getElementById('password').value;
     try {
+      setLoading(btn, true);
       await signInWithEmail(email, password);
     } catch (err) {
-      showToast(err.message, 'danger');
+      handleError(err);
+    } finally {
+      setLoading(btn, false);
     }
   });
 }
@@ -22,9 +26,12 @@ if (loginForm) {
 if (googleBtn) {
   googleBtn.addEventListener('click', async () => {
     try {
+      setLoading(googleBtn, true);
       await signInWithGoogle();
     } catch (err) {
-      showToast(err.message, 'danger');
+      handleError(err);
+    } finally {
+      setLoading(googleBtn, false);
     }
   });
 }
@@ -51,15 +58,19 @@ if (signupForm) {
       signupForm.reportValidity();
       return;
     }
+    const btn = signupForm.querySelector('button[type="submit"]');
     const email = document.getElementById('signup-email').value;
     const password = document.getElementById('signup-password').value;
     try {
+      setLoading(btn, true);
       await signUpWithEmail(email, password);
       showToast('Conta criada', 'success');
       signupForm.reset();
       window.location.href = 'index.html';
     } catch (err) {
-      showToast(err.message, 'danger');
+      handleError(err);
+    } finally {
+      setLoading(btn, false);
     }
   });
 }
@@ -73,14 +84,18 @@ if (resetForm) {
       resetForm.reportValidity();
       return;
     }
+    const btn = resetForm.querySelector('button[type="submit"]');
     const email = document.getElementById('reset-email').value;
     try {
+      setLoading(btn, true);
       await sendPasswordReset(email);
       showToast('E-mail enviado', 'success');
       resetForm.reset();
       window.location.href = 'index.html';
     } catch (err) {
-      showToast(err.message, 'danger');
+      handleError(err);
+    } finally {
+      setLoading(btn, false);
     }
   });
 }

--- a/onevision/hosting/assets/js/main.js
+++ b/onevision/hosting/assets/js/main.js
@@ -4,7 +4,7 @@ import { uploadFile } from './storage.service.js';
 import { watchProgress } from './realtime.service.js';
 import { isValidCNPJ, isAllowedFile } from './validators.js';
 import { renderReports } from './reports.view.js';
-import { showToast, setLoading } from './ui.js';
+import { showToast, setLoading, handleError, setDisabled } from './ui.js';
 import { signOutUser } from './auth.js';
 
 const cnpjInput = document.getElementById('cnpj');
@@ -24,7 +24,7 @@ cnpjInput.addEventListener('input', () => {
   const val = cnpjInput.value.replace(/\D/g, '');
   if (isValidCNPJ(val)) {
     currentCNPJ = val;
-    ensureCustomer(val, auth.currentUser.uid).catch(e => showToast(e.message, 'danger'));
+    ensureCustomer(val, auth.currentUser.uid).catch(handleError);
   } else {
     currentCNPJ = '';
   }
@@ -47,7 +47,7 @@ Object.entries(fileInputs).forEach(([type, input]) => {
 });
 
 function updateProcessBtn() {
-  processBtn.disabled = !(currentCNPJ && Object.keys(pending).length);
+  setDisabled(processBtn, !(currentCNPJ && Object.keys(pending).length));
 }
 
 processBtn.addEventListener('click', async () => {
@@ -81,7 +81,7 @@ processBtn.addEventListener('click', async () => {
     await loadReports();
     showToast('Processamento concluído', 'success');
   } catch (err) {
-    showToast(err.message, 'danger');
+    handleError(err);
   } finally {
     setLoading(processBtn, false);
     progressBar.style.width = '0%';

--- a/onevision/hosting/assets/js/ui.js
+++ b/onevision/hosting/assets/js/ui.js
@@ -12,18 +12,35 @@ export function showToast(message, type = 'info') {
   toast.show();
   toastEl.addEventListener('hidden.bs.toast', () => toastEl.remove());
 }
+const ERROR_MESSAGES = {
+  'auth/user-not-found': 'Usuário não encontrado',
+  'auth/wrong-password': 'Senha incorreta',
+  'auth/email-already-in-use': 'E-mail já cadastrado',
+  'auth/weak-password': 'Senha muito fraca',
+  'auth/invalid-email': 'E-mail inválido',
+  'auth/too-many-requests': 'Muitas tentativas, tente novamente mais tarde',
+  'auth/invalid-verification-code': 'Código MFA inválido',
+  'auth/invalid-mfa-code': 'Código MFA inválido'
+};
 
-export function setLoading(btn, loading) {
-  if (loading) {
-    btn.disabled = true;
-    btn.dataset.originalText = btn.innerHTML;
-    btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
-  } else {
-    btn.disabled = false;
-    if (btn.dataset.originalText) btn.innerHTML = btn.dataset.originalText;
-  }
+export function handleError(err) {
+  const message = ERROR_MESSAGES[err?.code] || err?.message || 'Erro desconhecido';
+  showToast(message, 'danger');
 }
 
 export function setDisabled(el, state) {
   el.disabled = state;
+  el.style.cursor = state ? 'not-allowed' : '';
+  el.style.opacity = state ? '0.6' : '';
+}
+
+export function setLoading(btn, loading) {
+  if (loading) {
+    setDisabled(btn, true);
+    btn.dataset.originalText = btn.innerHTML;
+    btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
+  } else {
+    setDisabled(btn, false);
+    if (btn.dataset.originalText) btn.innerHTML = btn.dataset.originalText;
+  }
 }


### PR DESCRIPTION
## Summary
- add reusable error handler with friendly messages
- style disabled buttons and reuse loading helper
- integrate loading feedback and error mapping in login and process flows

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68a87db608c88333afb7b74aa2ecf868