### PR TITLE
feat: replace 4Credit branding and add user menu

### DIFF
--- a/onevision/README.md
+++ b/onevision/README.md
@@ -1,4 +1,4 @@
-# VisionOne • 4Credit
+# VisionOne
 
 Aplicação de análise de arquivos financeiros (VADU, SERASA, SCR) com **Firebase Hosting + Functions** e UI alinhada ao **guia de design VisionOne**.
 

--- a/onevision/hosting/app.html
+++ b/onevision/hosting/app.html
@@ -14,31 +14,37 @@
 </head>
 <body class="font-family-base">
   <header>
-    <nav class="navbar navbar-expand-lg app-navbar">
+    <nav class="navbar app-navbar">
       <div class="container-fluid">
         <a class="navbar-brand mb-0 h1 brand-font with-icon" href="app.html">
             <img src="./assets/img/visionone-logo-h36.png" alt="VisionOne Credit Risk" class="brand-logo" height="36">
           <span>VisionOne • App</span>
         </a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNavbar" aria-controls="mainNavbar" aria-expanded="false" aria-label="Toggle navigation">
+        <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#mainMenu" aria-controls="mainMenu" aria-label="Abrir menu">
           <span class="navbar-toggler-icon"></span>
         </button>
-        <div class="collapse navbar-collapse" id="mainNavbar">
-          <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-            <li class="nav-item">
-              <a class="nav-link" href="app.html">Dashboard</a>
-            </li>
-            <li class="nav-item">
-              <a class="nav-link" href="manifesto.html">Manifesto</a>
-            </li>
-          </ul>
-          <button id="logout" class="btn btn-standard btn-outline-light btn-sm with-icon ms-lg-3">
-            <i class="bi bi-box-arrow-right"></i>
-            <span>Sair</span>
-          </button>
-        </div>
       </div>
     </nav>
+    <div class="offcanvas offcanvas-start" tabindex="-1" id="mainMenu">
+      <div class="offcanvas-body d-flex flex-column">
+        <div class="text-center mb-4">
+          <img id="user-photo" src="https://via.placeholder.com/64" alt="Foto do usuário" class="rounded-circle mb-2" width="64" height="64">
+          <p id="user-name" class="mb-0"></p>
+        </div>
+        <ul class="navbar-nav flex-grow-1">
+          <li class="nav-item">
+            <a class="nav-link" href="app.html">Dashboard</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="manifesto.html">Manifesto</a>
+          </li>
+        </ul>
+        <button id="logout" class="btn btn-standard btn-outline-secondary with-icon mt-auto w-100">
+          <i class="bi bi-box-arrow-right"></i>
+          <span>Sair</span>
+        </button>
+      </div>
+    </div>
   </header>
   <div class="container-xxl py-4">
     <div class="d-flex gap-4">

--- a/onevision/hosting/assets/js/main.js
+++ b/onevision/hosting/assets/js/main.js
@@ -5,12 +5,14 @@ import { watchProgress } from './realtime.service.js';
 import { isValidCNPJ, isAllowedFile } from './validators.js';
 import { renderReports } from './reports.view.js';
 import { showToast, setLoading, handleError, setDisabled } from './ui.js';
-import { signOutUser } from './auth.js';
+import { signOutUser, watchAuthState } from './auth.js';
 
 const cnpjInput = document.getElementById('cnpj');
 const processBtn = document.getElementById('process-btn');
 const progressBar = document.getElementById('progress-bar');
 const reportContainer = document.getElementById('reports');
+const userNameEl = document.getElementById('user-name');
+const userPhotoEl = document.getElementById('user-photo');
 const fileInputs = {
   VADU: document.getElementById('file-vadu'),
   SERASA: document.getElementById('file-serasa'),
@@ -98,5 +100,11 @@ async function loadReports() {
 }
 
 document.getElementById('logout').addEventListener('click', () => signOutUser());
+
+watchAuthState(user => {
+  if (!user) return;
+  if (userNameEl) userNameEl.textContent = user.displayName || user.email;
+  if (userPhotoEl) userPhotoEl.src = user.photoURL || 'https://via.placeholder.com/64';
+});
 
 window.addEventListener('load', loadReports);

--- a/onevision/hosting/index.html
+++ b/onevision/hosting/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>visionOne • 4Credit</title>
+  <title>VisionOne</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5waTHZ5PZr3QdorE2vLePoHB1zIYd2xt1kxgLZcflBNO8Y+0Y" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <link rel="stylesheet" href="./assets/css/theme.css">
@@ -17,7 +17,7 @@
     <section class="login-hero" style="background:var(--color-primary-900)">
       <div class="brand-bar with-icon brand-font">
         <img src="./assets/img/visionone-logo-h36.png" alt="VisionOne Credit Risk" class="brand-logo" height="36">
-        <h1 class="h5 m-0">VisionOne • 4Credit</h1>
+        <h1 class="h5 m-0">VisionOne</h1>
       </div>
       <h2 class="h3">A inteligência que vê o que outros não veem.</h2>
       <p class="text-white-50">Decida com comportamento, histórico e contexto.</p>

--- a/onevision/hosting/reset.html
+++ b/onevision/hosting/reset.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>visionOne • 4Credit</title>
+  <title>VisionOne</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5waTHZ5PZr3QdorE2vLePoHB1zIYd2xt1kxgLZcflBNO8Y+0Y" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <link rel="stylesheet" href="./assets/css/theme.css">
@@ -16,7 +16,7 @@
     <div class="card p-4 shadow-sm login-card">
         <div class="brand-bar with-icon brand-font">
           <img src="./assets/img/visionone-logo-h36.png" alt="VisionOne Credit Risk" class="brand-logo" height="36">
-          <h1 class="h5 m-0">VisionOne • 4Credit</h1>
+          <h1 class="h5 m-0">VisionOne</h1>
         </div>
       <h2 class="brand-font">Recuperar senha</h2>
       <p class="mb-4">Enviaremos instruções para o seu e-mail</p>

--- a/onevision/hosting/signup.html
+++ b/onevision/hosting/signup.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>visionOne • 4Credit</title>
+  <title>VisionOne</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5waTHZ5PZr3QdorE2vLePoHB1zIYd2xt1kxgLZcflBNO8Y+0Y" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
   <link rel="stylesheet" href="./assets/css/theme.css">
@@ -16,7 +16,7 @@
   <div class="card p-4 shadow-sm login-card">
       <div class="brand-bar with-icon brand-font">
         <img src="./assets/img/visionone-logo-h36.png" alt="VisionOne Credit Risk" class="brand-logo" height="36">
-        <h1 class="h5 m-0">VisionOne • 4Credit</h1>
+        <h1 class="h5 m-0">VisionOne</h1>
       </div>
     <h2 class="text-center mb-4 brand-font">Criar conta</h2>
     <form id="signup-form">


### PR DESCRIPTION
## Summary
- replace all 4Credit mentions with VisionOne across public pages and docs
- redesign app navigation with hamburger menu showing user info and logout
- populate menu with authenticated user details

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a8c0100b788333a32e8fda974f7220