### PR TITLE
feat: add PWA manifest and mobile sidebar

### DIFF
--- a/onevision/hosting/app.html
+++ b/onevision/hosting/app.html
@@ -11,11 +11,16 @@
   <link rel="stylesheet" href="./assets/css/app.css">
   <link rel="icon" type="image/png" href="./assets/img/visionone-favicon-32.png">
   <link rel="apple-touch-icon" href="./assets/img/visionone-icon-180.png">
+  <link rel="manifest" href="./manifest.webmanifest">
 </head>
 <body class="font-family-base">
   <header>
     <nav class="navbar navbar-expand-lg navbar-dark app-navbar">
       <div class="container-fluid">
+        <button class="btn btn-outline-light d-lg-none me-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#sidebar" aria-controls="sidebar">
+          <i class="bi bi-layout-sidebar-inset"></i>
+          <span class="visually-hidden">Abrir menu</span>
+        </button>
         <a class="navbar-brand d-flex align-items-center gap-2" href="app.html">
           <img src="./assets/img/visionone-logo-h24.png" height="24" alt="VisionOne Credit Risk">
           <span class="brand-font">VisionOne • App</span>
@@ -40,39 +45,45 @@
   </header>
   <div class="container-xxl py-4">
     <div class="d-flex gap-4">
-      <aside class="sidebar-modern">
-        <nav class="sidebar-nav mb-3">
-          <a class="sidebar-item active with-icon" href="app.html"><i class="bi bi-house"></i> Início</a>
-          <a class="sidebar-item with-icon" href="#"><i class="bi bi-building"></i> Empresas</a>
-          <a class="sidebar-item with-icon" href="#"><i class="bi bi-file-earmark-text"></i> Relatórios</a>
-          <a class="sidebar-item with-icon" href="#"><i class="bi bi-bell"></i> Alertas</a>
-          <a class="sidebar-item with-icon" href="#"><i class="bi bi-gear"></i> Regras</a>
-          <a class="sidebar-item with-icon" href="#"><i class="bi bi-plug"></i> Integrações</a>
-          <a class="sidebar-item with-icon" href="#"><i class="bi bi-shield-lock"></i> Admin & LGPD</a>
-        </nav>
-        <hr>
-        <div class="form-floating">
-          <input type="text" id="cnpj" class="form-control form-control-lg input-standard" placeholder="00.000.000/0000-00">
-          <label for="cnpj">CNPJ</label>
+      <aside id="sidebar" class="sidebar-modern offcanvas-lg offcanvas-start" tabindex="-1" aria-labelledby="sidebarLabel" data-bs-scroll="true" style="--bs-offcanvas-width: 300px;">
+        <div class="offcanvas-header d-lg-none">
+          <h5 class="offcanvas-title brand-font" id="sidebarLabel">Menu</h5>
+          <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Fechar"></button>
         </div>
-        <label class="btn btn-standard btn-outline-secondary upload-btn with-icon">
-          <i class="bi bi-file-earmark-text"></i>
-          <span>VADU</span>
-          <input type="file" id="file-vadu" hidden>
-        </label>
-        <label class="btn btn-standard btn-outline-secondary upload-btn with-icon">
-          <i class="bi bi-building"></i>
-          <span>SERASA</span>
-          <input type="file" id="file-serasa" hidden>
-        </label>
-        <label class="btn btn-standard btn-outline-secondary upload-btn with-icon">
-          <i class="bi bi-bank"></i>
-          <span>SCR</span>
-          <input type="file" id="file-scr" hidden>
-        </label>
-        <button id="process-btn" class="btn btn-standard btn-primary w-100" disabled>Processar</button>
-        <div class="progress mt-2" style="height: 6px;">
-          <div id="progress-bar" class="progress-bar" role="progressbar"></div>
+        <div class="offcanvas-body p-0">
+          <nav class="sidebar-nav mb-3">
+            <a class="sidebar-item active with-icon" href="app.html"><i class="bi bi-house"></i> Início</a>
+            <a class="sidebar-item with-icon" href="#"><i class="bi bi-building"></i> Empresas</a>
+            <a class="sidebar-item with-icon" href="#"><i class="bi bi-file-earmark-text"></i> Relatórios</a>
+            <a class="sidebar-item with-icon" href="#"><i class="bi bi-bell"></i> Alertas</a>
+            <a class="sidebar-item with-icon" href="#"><i class="bi bi-gear"></i> Regras</a>
+            <a class="sidebar-item with-icon" href="#"><i class="bi bi-plug"></i> Integrações</a>
+            <a class="sidebar-item with-icon" href="#"><i class="bi bi-shield-lock"></i> Admin & LGPD</a>
+          </nav>
+          <hr class="my-3">
+          <div class="form-floating">
+            <input type="text" id="cnpj" class="form-control form-control-lg input-standard" placeholder="00.000.000/0000-00">
+            <label for="cnpj">CNPJ</label>
+          </div>
+          <label class="btn btn-standard btn-outline-secondary upload-btn with-icon">
+            <i class="bi bi-file-earmark-text"></i>
+            <span>VADU</span>
+            <input type="file" id="file-vadu" hidden>
+          </label>
+          <label class="btn btn-standard btn-outline-secondary upload-btn with-icon">
+            <i class="bi bi-building"></i>
+            <span>SERASA</span>
+            <input type="file" id="file-serasa" hidden>
+          </label>
+          <label class="btn btn-standard btn-outline-secondary upload-btn with-icon">
+            <i class="bi bi-bank"></i>
+            <span>SCR</span>
+            <input type="file" id="file-scr" hidden>
+          </label>
+          <button id="process-btn" class="btn btn-standard btn-primary w-100" disabled>Processar</button>
+          <div class="progress mt-2" style="height: 6px;">
+            <div id="progress-bar" class="progress-bar" role="progressbar"></div>
+          </div>
         </div>
       </aside>
       <main class="flex-grow-1">

--- a/onevision/hosting/assets/css/app.css
+++ b/onevision/hosting/assets/css/app.css
@@ -124,3 +124,21 @@ main.flex-grow-1 {
     flex: 0 0 280px;
   }
 }
+
+/* Offcanvas width and behavior */
+#sidebar.offcanvas,
+#sidebar.offcanvas-lg {
+  --bs-offcanvas-width: 300px;
+}
+
+@media (min-width: 992px) {
+  #sidebar.offcanvas-lg {
+    position: static;
+    transform: none !important;
+    visibility: visible !important;
+    background: transparent;
+    border: 0;
+  }
+  #sidebar .offcanvas-header { display: none; }
+  #sidebar .offcanvas-body { padding: 0; }
+}

--- a/onevision/hosting/assets/css/theme.css
+++ b/onevision/hosting/assets/css/theme.css
@@ -199,3 +199,25 @@ a:focus {
   border-radius: var(--radius-md);
 }
 
+/* Chips for risk severity */
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  line-height: 1;
+  border: 1px solid transparent;
+}
+.chip.pos {
+  background: rgba(18,183,106,0.1);
+  color: var(--color-risk-pos);
+  border-color: rgba(18,183,106,0.25);
+}
+.chip.neg {
+  background: rgba(225,29,72,0.1);
+  color: var(--color-risk-neg);
+  border-color: rgba(225,29,72,0.25);
+}
+

--- a/onevision/hosting/index.html
+++ b/onevision/hosting/index.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" href="./assets/css/login.css">
   <link rel="icon" type="image/png" href="./assets/img/visionone-favicon-32.png">
   <link rel="apple-touch-icon" href="./assets/img/visionone-icon-180.png">
+  <link rel="manifest" href="./manifest.webmanifest">
 </head>
 <body class="login-body font-family-base">
   <main class="login-grid">

--- a/onevision/hosting/manifest.webmanifest
+++ b/onevision/hosting/manifest.webmanifest
@@ -1,0 +1,17 @@
+{
+  "name": "VisionOne • 4Credit",
+  "short_name": "VisionOne",
+  "description": "Aplicação de análise de arquivos financeiros com IA para crédito comportamental.",
+  "start_url": "/index.html",
+  "display": "standalone",
+  "background_color": "#032052",
+  "theme_color": "#032052",
+  "orientation": "any",
+  "icons": [
+    {"src": "./assets/img/visionone-favicon-32.png", "sizes": "32x32", "type": "image/png"},
+    {"src": "./assets/img/visionone-icon-180.png", "sizes": "180x180", "type": "image/png", "purpose": "any maskable"},
+    {"src": "./assets/img/visionone-icon-192.png", "sizes": "192x192", "type": "image/png", "purpose": "any maskable"},
+    {"src": "./assets/img/visionone-icon-256.png", "sizes": "256x256", "type": "image/png"},
+    {"src": "./assets/img/visionone-icon-512.png", "sizes": "512x512", "type": "image/png", "purpose": "any maskable"}
+  ]
+}

--- a/onevision/hosting/manifesto.html
+++ b/onevision/hosting/manifesto.html
@@ -5,6 +5,7 @@
 <link rel="stylesheet" href="./assets/css/theme.css">
 <link rel="stylesheet" href="./assets/css/bootstrap.custom.css">
 <link rel="icon" type="image/png" href="./assets/img/visionone-favicon-32.png"><link rel="apple-touch-icon" href="./assets/img/visionone-icon-180.png">
+<link rel="manifest" href="./manifest.webmanifest">
 </head><body class="font-family-base">
   <header class="border-bottom bg-white">
     <div class="container-xxl d-flex align-items-center py-3 with-icon">

--- a/onevision/hosting/reset.html
+++ b/onevision/hosting/reset.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="./assets/css/login.css">
     <link rel="icon" type="image/png" href="./assets/img/visionone-favicon-32.png">
     <link rel="apple-touch-icon" href="./assets/img/visionone-icon-180.png">
+    <link rel="manifest" href="./manifest.webmanifest">
   </head>
 <body class="login-body font-family-base">
     <div class="card p-4 shadow-sm login-card">

--- a/onevision/hosting/signup.html
+++ b/onevision/hosting/signup.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="./assets/css/login.css">
     <link rel="icon" type="image/png" href="./assets/img/visionone-favicon-32.png">
     <link rel="apple-touch-icon" href="./assets/img/visionone-icon-180.png">
+    <link rel="manifest" href="./manifest.webmanifest">
 </head>
 <body class="login-body font-family-base">
   <div class="card p-4 shadow-sm login-card">


### PR DESCRIPTION
## Summary
- add web app manifest and link across pages
- add mobile offcanvas sidebar with toggler
- style reports with risk chips utilities

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68a8c5d9b7ac8333800da72f3bea6f1f