### PR TITLE
feat: collapse app navbar with scoped styles

### DIFF
--- a/onevision/hosting/app.html
+++ b/onevision/hosting/app.html
@@ -17,28 +17,25 @@
   <header>
     <nav class="navbar navbar-expand-lg navbar-dark app-navbar">
       <div class="container-fluid">
-        <button class="btn btn-outline-light d-lg-none me-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#sidebar" aria-controls="sidebar">
-          <i class="bi bi-layout-sidebar-inset"></i>
-          <span class="visually-hidden">Abrir menu</span>
-        </button>
-        <a class="navbar-brand d-flex align-items-center gap-2" href="app.html">
-          <img src="./assets/img/visionone-logo-h24.png" height="24" alt="VisionOne Credit Risk">
-          <span class="brand-font">VisionOne • App</span>
+        <a class="navbar-brand mb-0 h1 brand-font with-icon" href="app.html">
+          <img src="./assets/img/visionone-logo-h24.png" class="brand-logo" alt="VisionOne Credit Risk" height="24">
+          <span>VisionOne • App</span>
         </a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#appNav" aria-controls="appNav" aria-expanded="false" aria-label="Alternar navegação">
+
+        <button class="navbar-toggler" type="button"
+                data-bs-toggle="collapse" data-bs-target="#mainNavbar"
+                aria-controls="mainNavbar" aria-expanded="false" aria-label="Alternar navegação">
           <span class="navbar-toggler-icon"></span>
         </button>
-        <div class="collapse navbar-collapse" id="appNav">
+
+        <div class="collapse navbar-collapse" id="mainNavbar">
           <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-            <li class="nav-item"><a class="nav-link" href="./app.html">Dashboard</a></li>
-            <li class="nav-item"><a class="nav-link" href="./manifesto.html">Manifesto</a></li>
+            <li class="nav-item"><a class="nav-link" href="app.html">Dashboard</a></li>
+            <li class="nav-item"><a class="nav-link" href="manifesto.html">Manifesto</a></li>
           </ul>
-          <div class="d-flex align-items-center">
-            <img src="./assets/img/visionone-logo-h24.png" height="24" alt="" class="me-3 d-none d-lg-inline opacity-50">
-            <button id="logout" class="btn btn-standard btn-outline-light btn-sm with-icon ms-lg-2">
-              <i class="bi bi-box-arrow-right"></i><span>Sair</span>
-            </button>
-          </div>
+          <button id="logout" class="btn btn-standard btn-outline-light btn-sm with-icon ms-lg-2">
+            <i class="bi bi-box-arrow-right"></i><span>Sair</span>
+          </button>
         </div>
       </div>
     </nav>
@@ -96,6 +93,6 @@
   </footer>
   <script type="module" src="./assets/js/auth.js"></script>
   <script type="module" src="./assets/js/main.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/onevision/hosting/assets/css/app.css
+++ b/onevision/hosting/assets/css/app.css
@@ -1,26 +1,3 @@
-/* Skin da navbar do app (fundo navy + texto claro) */
-.app-navbar{
-  background: var(--color-primary-900);
-  border-bottom: 1px solid rgba(255,255,255,.08);
-  /* variáveis do Bootstrap para navbar-dark */
-  --bs-navbar-color: rgba(255,255,255,.85);
-  --bs-navbar-hover-color: #fff;
-  --bs-navbar-brand-color: #fff;
-  --bs-navbar-toggler-border-color: rgba(255,255,255,.35);
-}
-.app-navbar .navbar-brand,
-.app-navbar .nav-link{ color: var(--bs-navbar-color); }
-.app-navbar .nav-link:hover{ color: var(--bs-navbar-hover-color); }
-
-/* Garantir ícone visível do toggler em tema escuro */
-.navbar-dark .navbar-toggler-icon{
-  /* usa o ícone padrão do Bootstrap para dark */
-  background-image: var(--bs-navbar-toggler-icon-bg);
-}
-
-/* Respiro pro botão Sair */
-#logout{ margin-left: .5rem; }
-
 .sidebar-modern {
   flex: 1 1 240px;
   min-width: 200px;
@@ -127,18 +104,39 @@ main.flex-grow-1 {
 
 /* Offcanvas width and behavior */
 #sidebar.offcanvas,
-#sidebar.offcanvas-lg {
-  --bs-offcanvas-width: 300px;
+  #sidebar.offcanvas-lg {
+    --bs-offcanvas-width: 300px;
+  }
+
+  @media (min-width: 992px) {
+    #sidebar.offcanvas-lg {
+      position: static;
+      transform: none !important;
+      visibility: visible !important;
+      background: transparent;
+      border: 0;
+    }
+    #sidebar .offcanvas-header { display: none; }
+    #sidebar .offcanvas-body { padding: 0; }
+  }
+
+/* Skin da navbar do app */
+.app-navbar{
+  background: var(--color-primary-900);
+  border-bottom: 1px solid rgba(255,255,255,.08);
+  --bs-navbar-color: rgba(255,255,255,.85);
+  --bs-navbar-hover-color: #fff;
+  --bs-navbar-brand-color: #fff;
+  --bs-navbar-toggler-border-color: rgba(255,255,255,.35);
+}
+.app-navbar .navbar-brand,
+.app-navbar .nav-link{ color: var(--bs-navbar-color); }
+.app-navbar .nav-link:hover{ color: var(--bs-navbar-hover-color); }
+
+/* garante as 3 listras visíveis no tema dark */
+.navbar-dark .navbar-toggler-icon{
+  background-image: var(--bs-navbar-toggler-icon-bg);
 }
 
-@media (min-width: 992px) {
-  #sidebar.offcanvas-lg {
-    position: static;
-    transform: none !important;
-    visibility: visible !important;
-    background: transparent;
-    border: 0;
-  }
-  #sidebar .offcanvas-header { display: none; }
-  #sidebar .offcanvas-body { padding: 0; }
-}
+/* respiro do botão sair */
+#logout{ margin-left:.5rem; }

--- a/onevision/hosting/assets/css/bootstrap.custom.css
+++ b/onevision/hosting/assets/css/bootstrap.custom.css
@@ -14,7 +14,8 @@ body {
   padding-top: 60px;
 }
 
-.navbar {
+/* Mantém navbars padrão brancas, mas não interfere na do app */
+.navbar:not(.app-navbar){
   background: #fff;
   border-bottom: 1px solid var(--color-neutral-200);
 }


### PR DESCRIPTION
## Summary
- replace navbar markup with a collapsible version and scoped logout button
- isolate global navbar overrides from app theme
- append app-specific navbar skin for dark theme

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a8c9fb36448333b140d2a861c3faf7