### PR TITLE
Add Google signup handler

### DIFF
--- a/onevision/hosting/assets/js/login.js
+++ b/onevision/hosting/assets/js/login.js
@@ -66,11 +66,26 @@ if (signupForm) {
       await signUpWithEmail(email, password);
       showToast('Conta criada', 'success');
       signupForm.reset();
-      window.location.href = 'index.html';
+      window.location.href = 'app.html';
     } catch (err) {
       handleError(err);
     } finally {
       setLoading(btn, false);
+    }
+  });
+}
+
+const googleSignupBtn = document.getElementById('google-signup');
+if (googleSignupBtn) {
+  googleSignupBtn.addEventListener('click', async () => {
+    try {
+      setLoading(googleSignupBtn, true);
+      await signInWithGoogle();
+      window.location.href = 'app.html';
+    } catch (err) {
+      handleError(err);
+    } finally {
+      setLoading(googleSignupBtn, false);
     }
   });
 }


### PR DESCRIPTION
## Summary
- handle Google-based sign-up via `signInWithGoogle`
- redirect new accounts to `app.html`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68ae74e27a98833399bba5ed6e8eb978