### PR TITLE
feat: add cedente classification service with alerts

### DIFF
--- a/onevision/functions/package.json
+++ b/onevision/functions/package.json
@@ -5,7 +5,8 @@
   "engines": { "node": "20" },
   "scripts": {
     "serve": "firebase emulators:start --only functions",
-    "deploy": "firebase deploy --only functions"
+    "deploy": "firebase deploy --only functions",
+    "test": "node --test"
   },
   "dependencies": {
     "firebase-admin": "^11.11.0",

--- a/onevision/functions/src/services/classificacao.service.js
+++ b/onevision/functions/src/services/classificacao.service.js
@@ -1,0 +1,50 @@
+import { SituacaoCadastral } from '../models/cedente.model.js';
+import { IQCCalculator } from './iqc.service.js';
+import { IsCorteAutomatico, ParecerResultado } from './parecer.service.js';
+import { ConsultaAnalyzer } from './consulta-analyzer.service.js';
+
+/**
+ * Classifica um cedente aplicando regras de corte, cálculo de IQC e geração de alertas.
+ * @param {string} cnpj
+ * @param {object} dados
+ * @returns {{cnpj:string, situacaoCadastral:string|null, corte:string|null, iqc:object|null, consultas:object|null, alertas:string[]}}
+ */
+export function ClassificarCedente(cnpj, dados = {}) {
+  const result = {
+    cnpj,
+    situacaoCadastral: dados.situacaoCadastral || null,
+    corte: null,
+    iqc: null,
+    consultas: null,
+    alertas: []
+  };
+
+  // Pré-validação da situação cadastral
+  if (dados.situacaoCadastral && dados.situacaoCadastral !== SituacaoCadastral.ATIVA) {
+    result.corte = 'SituacaoCadastral';
+    return result;
+  }
+
+  // Corte automático (curto-circuito)
+  const corte = IsCorteAutomatico(dados, dados.historicoSocios || []);
+  result.corte = corte;
+  if (corte !== ParecerResultado.OK) {
+    return result;
+  }
+
+  // Cálculo do IQC
+  const iqc = IQCCalculator.Calculate(dados);
+  result.iqc = iqc;
+
+  // Geração de alertas
+  const consultas = ConsultaAnalyzer.analyze(dados.consultasCredito || []);
+  result.consultas = consultas;
+  if (consultas.AlertasEEN && consultas.AlertasEEN.length) {
+    result.alertas.push(...consultas.AlertasEEN);
+  }
+  if (iqc.alteracoesSuspeitas) {
+    result.alertas.push('AlteracoesSuspeitas');
+  }
+
+  return result;
+}

--- a/onevision/functions/test/classificarCedente.test.js
+++ b/onevision/functions/test/classificarCedente.test.js
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ClassificarCedente } from '../src/services/classificacao.service.js';
+import { ParecerResultado } from '../src/services/parecer.service.js';
+import { SituacaoCadastral, SetorRisco } from '../src/models/cedente.model.js';
+import { Parecer } from '../src/models/iqc.model.js';
+
+// Scenario: automatic cut
+test('corta cedente com protesto FIDC', () => {
+  const cedente = {
+    situacaoCadastral: SituacaoCadastral.ATIVA,
+    protestos: [{ credor: 'FIDC Alpha', valor: 1000 }]
+  };
+  const res = ClassificarCedente('00000000000100', cedente);
+  assert.equal(res.corte, ParecerResultado.ProtestoFIDC);
+  assert.equal(res.iqc, null);
+});
+
+// Scenario: favorable IQC
+test('retorna IQC favoravel', () => {
+  const cedente = {
+    situacaoCadastral: SituacaoCadastral.ATIVA,
+    faturamentos: [{ valor: 2000000 }],
+    idade: 10,
+    setorRisco: SetorRisco.BAIXO,
+    pontualidade: { indice: 90 }
+  };
+  const res = ClassificarCedente('00000000000200', cedente);
+  assert.equal(res.corte, ParecerResultado.OK);
+  assert.ok(res.iqc);
+  assert.equal(res.iqc.parecer, Parecer.FAVORAVEL);
+});
+
+// Scenario: unfavorable IQC
+test('retorna IQC desfavoravel', () => {
+  const cedente = {
+    situacaoCadastral: SituacaoCadastral.ATIVA,
+    faturamentos: [{ valor: 500000 }],
+    protestos: [{ credor: 'Banco XYZ', valor: 300000 }],
+    endividamentoFiscal: 500000
+  };
+  const res = ClassificarCedente('00000000000300', cedente);
+  assert.equal(res.corte, ParecerResultado.OK);
+  assert.ok(res.iqc.score < 0);
+  assert.equal(res.iqc.parecer, Parecer.DESFAVORAVEL);
+});
+
+// Scenario: alerts generation
+test('gera alertas de consultas e alteracoes suspeitas', () => {
+  const consultas = Array.from({ length: 11 }).map((_, i) => ({
+    data: new Date(2023, i, 1).toISOString(),
+    fonte: 'FIDC ' + i
+  }));
+  const cedente = {
+    situacaoCadastral: SituacaoCadastral.ATIVA,
+    consultasCredito: consultas,
+    faturamentos: [{ valor: 1000000 }],
+    protestos: [{ credor: 'Banco X', valor: 1000, data: '2023-01-10' }],
+    alteracoesCadastrais: [{ data: '2023-01-20', descricao: 'Mudança' }]
+  };
+  const res = ClassificarCedente('00000000000400', cedente);
+  assert.equal(res.corte, ParecerResultado.OK);
+  assert.ok(res.alertas.includes('ConsultasFIDC>10'));
+  assert.ok(res.alertas.includes('AlteracoesSuspeitas'));
+});


### PR DESCRIPTION
## Summary
- add `ClassificarCedente` service to evaluate cedente data, compute IQC and generate alerts
- add tests covering automatic cuts, favorable/unfavorable scores and alert scenarios
- add npm test script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bfd1896d388333ab398cdef8b1c53b